### PR TITLE
Fixed inconsistency between function declaration and definition

### DIFF
--- a/st7735/st7735.c
+++ b/st7735/st7735.c
@@ -303,10 +303,10 @@ void ST7735_InvertColors(bool invert) {
     ST7735_Unselect();
 }
 
-void ST7735_SetGamma(uint8_t gamma)
+void ST7735_SetGamma(GammaDef gamma)
 {
 	ST7735_Select();
 	ST7735_WriteCommand(ST7735_GAMSET);
-	ST7735_WriteData(&gamma, sizeof(gamma));
+	ST7735_WriteData((uint8_t *) &gamma, sizeof(gamma));
 	ST7735_Unselect();
 }


### PR DESCRIPTION
Due to a mismatch between the parameter type in the definition and the actual implementation code, the ST7735_SetGamma function, which is defined with a parameter of type GammaDef enum, was using uint8_t in its implementation code, resulting in a compilation failure.